### PR TITLE
Add Windows executable build workflow

### DIFF
--- a/.github/workflows/build-kiosk-exe.yml
+++ b/.github/workflows/build-kiosk-exe.yml
@@ -1,0 +1,36 @@
+name: Build kiosk executable
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt -r kiosk_app/requirements.txt pyinstaller
+
+      - name: Validate backend start-up
+        run: python combined_launcher.py --check-backend
+
+      - name: Build Windows executable
+        run: python scripts/build_executable.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kiosk_app_executable
+          path: dist/kiosk_app.exe

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@
 - API: http://127.0.0.1:8000/health
 - Мини‑админка: http://127.0.0.1:8000/admin
 
+### Сборка автономного `.exe`
+
+Для создания Windows‑исполняемого файла, который поднимает бэкенд и клиент одним процессом, используется `PyInstaller` и точка входа `combined_launcher.py`.
+
+Локально (Linux/macOS/Windows):
+
+```bash
+pip install -r backend/requirements.txt -r kiosk_app/requirements.txt pyinstaller
+python scripts/build_executable.py
+```
+
+Готовый файл появится в каталоге `dist/` (`kiosk_app.exe` на Windows). Быстрый тест бэкенда без запуска UI:
+
+```bash
+python combined_launcher.py --check-backend
+```
+
 ## Что входит
 - Публичные эндпойнты: `/config`, `/home/buttons`, `/pages/{slug}`, `/upload`
 - Мок‑данные (в памяти) для кнопок/страниц/темы

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,10 +1,26 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, DeclarativeBase
+from __future__ import annotations
 
-DATABASE_URL = "sqlite:///app/kiosk.db"  # файл рядом с backend/app
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+
+def _resolve_database_url() -> str:
+    """Return an absolute SQLite URL pointing to the bundled DB file."""
+
+    base_dir = Path(__file__).resolve().parent
+    db_path = base_dir / "kiosk.db"
+    # sqlite expects forward slashes in URLs even on Windows
+    return f"sqlite:///{db_path.as_posix()}"
+
+
+DATABASE_URL = _resolve_database_url()
+
 
 engine = create_engine(
-    DATABASE_URL, connect_args={"check_same_thread": False}
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.111.0
-uvicorn[standard]==0.29.0
+uvicorn[standard]==0.29.0; sys_platform != "win32"
+uvicorn==0.29.0; sys_platform == "win32"
 python-multipart==0.0.9
 Jinja2==3.1.4
 pydantic==2.7.4

--- a/combined_launcher.py
+++ b/combined_launcher.py
@@ -62,7 +62,8 @@ class BackendServer:
         self._thread.start()
         deadline = time.monotonic() + self._startup_timeout
         while time.monotonic() < deadline:
-            if self._server.started:
+            started_event = getattr(self._server, "started", None)
+            if started_event is not None and started_event.is_set():
                 return
             if not self._thread.is_alive():
                 raise RuntimeError("Backend server thread exited before start-up completed")

--- a/combined_launcher.py
+++ b/combined_launcher.py
@@ -1,0 +1,191 @@
+"""Run the backend API and kiosk UI from a single executable."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import threading
+import time
+from typing import Iterable
+
+
+def _resource_path(*relative: str) -> str:
+    """Return an absolute path for bundled resources."""
+
+    base = getattr(sys, "_MEIPASS", None)
+    if base:
+        root = base
+    else:
+        root = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(root, *relative)
+
+
+def _ensure_sys_path(paths: Iterable[str]) -> None:
+    for path in paths:
+        if path and os.path.isdir(path) and path not in sys.path:
+            sys.path.insert(0, path)
+
+
+class BackendServer:
+    """Helper that runs uvicorn in a background thread."""
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        log_level: str = "info",
+        startup_timeout: float = 20.0,
+    ) -> None:
+        import uvicorn
+
+        self.host = host
+        self.port = port
+        self._startup_timeout = startup_timeout
+        self._server = uvicorn.Server(
+            uvicorn.Config(
+                "backend.app.main:app",
+                host=host,
+                port=port,
+                log_level=log_level,
+                reload=False,
+            )
+        )
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._stop_lock = threading.Lock()
+        self._stopped = False
+
+    def start(self) -> None:
+        if self._thread.is_alive():
+            return
+
+        self._thread.start()
+        deadline = time.monotonic() + self._startup_timeout
+        while time.monotonic() < deadline:
+            if self._server.started:
+                return
+            if not self._thread.is_alive():
+                raise RuntimeError("Backend server thread exited before start-up completed")
+            time.sleep(0.1)
+
+        raise TimeoutError("Backend server did not start in time")
+
+    def stop(self, wait: bool = True, timeout: float = 5.0) -> None:
+        with self._stop_lock:
+            if self._stopped:
+                wait = wait and self._thread.is_alive()
+            else:
+                self._stopped = True
+                if self._server:
+                    self._server.should_exit = True
+        if wait and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+            if self._thread.is_alive() and self._server:
+                self._server.force_exit = True
+                self._thread.join(timeout=1.0)
+
+
+def _install_qt_message_filter() -> None:
+    """Hide noisy Qt log messages that clutter stdout."""
+
+    try:
+        from PySide6.QtCore import QtMsgType, qInstallMessageHandler
+    except Exception:  # pragma: no cover - Qt is optional during linting/tests
+        return
+
+    previous_handler = None
+
+    def _handler(mode: QtMsgType, context, message: str) -> None:  # type: ignore[override]
+        if isinstance(message, str) and "AVStream duration -9223372036854775808 is invalid" in message:
+            return
+        if previous_handler:
+            previous_handler(mode, context, message)  # type: ignore[arg-type]
+
+    previous_handler = qInstallMessageHandler(_handler)
+
+
+def _run_qt_frontend(server: BackendServer) -> int:
+    from PySide6.QtWidgets import QApplication
+
+    from kiosk_app.main import App
+
+    _install_qt_message_filter()
+
+    app = QApplication(sys.argv)
+
+    window = App()
+    width = int(os.environ.get("KIOSK_WINDOW_WIDTH", "1280"))
+    height = int(os.environ.get("KIOSK_WINDOW_HEIGHT", "800"))
+    window.resize(width, height)
+    window.show()
+
+    def _shutdown() -> None:
+        server.stop()
+
+    app.aboutToQuit.connect(_shutdown)  # type: ignore[arg-type]
+
+    exit_code = 0
+    try:
+        exit_code = app.exec()
+    finally:
+        server.stop()
+    return exit_code
+
+
+def _check_backend_health(server: BackendServer, retries: int = 20) -> None:
+    import requests
+
+    url = f"http://{server.host}:{server.port}/health"
+    for _ in range(retries):
+        try:
+            response = requests.get(url, timeout=2)
+        except requests.RequestException:
+            time.sleep(0.5)
+            continue
+        if response.ok:
+            print("Backend health check succeeded.")
+            return
+        time.sleep(0.5)
+
+    raise RuntimeError("Backend health check failed")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run kiosk backend and UI together.")
+    parser.add_argument(
+        "--check-backend",
+        action="store_true",
+        help="Start the backend, perform a health check and exit (no UI).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    base_dir = _resource_path()
+    backend_dir = _resource_path("backend")
+    kiosk_dir = _resource_path("kiosk_app")
+    _ensure_sys_path({base_dir, backend_dir, kiosk_dir})
+
+    # When frozen, ensure the backend uses its bundled data directory
+    if backend_dir:
+        os.environ.setdefault("KIOSK_BACKEND_BASE", backend_dir)
+
+    server = BackendServer(
+        host=os.environ.get("KIOSK_BACKEND_HOST", "127.0.0.1"),
+        port=int(os.environ.get("KIOSK_BACKEND_PORT", "8000")),
+    )
+
+    try:
+        server.start()
+        if args.check_backend:
+            _check_backend_health(server)
+            return 0
+        return _run_qt_frontend(server)
+    finally:
+        server.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    sys.exit(main())

--- a/scripts/build_executable.py
+++ b/scripts/build_executable.py
@@ -1,0 +1,44 @@
+"""Helper script to build the packaged kiosk executable with PyInstaller."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import PyInstaller.__main__
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ENTRYPOINT = ROOT / "combined_launcher.py"
+
+
+def _format_data_path(source: pathlib.Path, target: str) -> str:
+    """Return an --add-data argument that works on any platform."""
+
+    return f"{source}{os.pathsep}{target}"
+
+
+def main() -> None:
+    datas = [
+        _format_data_path(ROOT / "backend" / "app" / "static", "backend/app/static"),
+        _format_data_path(ROOT / "backend" / "app" / "templates", "backend/app/templates"),
+        _format_data_path(ROOT / "backend" / "media", "backend/media"),
+        _format_data_path(ROOT / "backend" / "app" / "kiosk.db", "backend/app/kiosk.db"),
+    ]
+
+    args = [
+        str(ENTRYPOINT),
+        "--name",
+        "kiosk_app",
+        "--onefile",
+        "--noconfirm",
+        "--clean",
+    ]
+    for data in datas:
+        args.extend(["--add-data", data])
+
+    PyInstaller.__main__.run(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a bundled launcher that starts uvicorn in-process with the Qt kiosk UI and supports a backend health check mode
- resolve the SQLite database path relative to the backend package and adjust requirements for Windows compatibility
- document executable packaging, add a PyInstaller helper script, and create a Windows workflow that builds and uploads the artifact

## Testing
- python combined_launcher.py --check-backend
- python scripts/build_executable.py
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68c9ac20009883248686ab162abb662d